### PR TITLE
Reversed logic for which message to show

### DIFF
--- a/src/jsx/components/ui/AreaDetailsMeta.js
+++ b/src/jsx/components/ui/AreaDetailsMeta.js
@@ -24,9 +24,11 @@ export default (props) => (
 
     <div className="c-area-meta__links">
       {
-        props.data.geography.geo_type === 'Zip'
-        ? <p>Corresponding zip codes include:</p>
-        : <p>Corresponding community areas include:</p>
+        props.data.geography.geo_type === 'Zip' ? (
+          <p>Corresponding community areas include:</p>
+        ) : (
+          <p>Corresponding zip codes include:</p>
+        )
       }
       {renderAdjecentAreas(props.data)}
     </div>


### PR DESCRIPTION
## Description
The wrong message was showing for the situation. It if we're currently looking at a geographical area based on zip it makes sense to show the community areas message instead.

Also made the ternary more inline with current react style.

## Screenshots
<img width="1040" alt="screen shot 2018-07-21 at 7 32 51 pm" src="https://user-images.githubusercontent.com/11019755/43041163-6deb66b0-8d1d-11e8-9efa-ef87f6ba3704.png">
<img width="1038" alt="screen shot 2018-07-21 at 7 39 55 pm" src="https://user-images.githubusercontent.com/11019755/43041176-e61cfc34-8d1d-11e8-84e6-d67e85bf26de.png">
